### PR TITLE
release: v0.3.23

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.4",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "6e076a124f7ee146f2487554a94b6a19a74887ba"
+                "reference": "f28d44c286812c714741478d968104c5e604a1d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6e076a124f7ee146f2487554a94b6a19a74887ba",
-                "reference": "6e076a124f7ee146f2487554a94b6a19a74887ba",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f28d44c286812c714741478d968104c5e604a1d4",
+                "reference": "f28d44c286812c714741478d968104c5e604a1d4",
                 "shasum": ""
             },
             "require": {
@@ -52,7 +52,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/1.4.4"
+                "source": "https://github.com/composer/xdebug-handler/tree/1.4.5"
             },
             "funding": [
                 {
@@ -68,7 +68,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T12:39:10+00:00"
+            "time": "2020-11-13T08:04:11+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update dependencies (4c0bc75653524d33b15cde8e8f93a33b19f2062e)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/technote-space/igo-php/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>composer packages</em></summary>

### stderr:

```Shell
> mkdir -p ./fixtures/.git
> chmod -R +w ./fixtures/.git && rm -rdf ./fixtures
> git clone --depth=1 https://github.com/wp-content-framework/fixtures.git fixtures
Cloning into 'fixtures'...
> composer install --no-interaction --prefer-dist --no-suggest
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Package operations: 36 installs, 0 updates, 0 removals
  - Downloading squizlabs/php_codesniffer (3.5.8)
  - Downloading dealerdirect/phpcodesniffer-composer-installer (v0.7.0)
  - Downloading symfony/polyfill-ctype (v1.19.0)
  - Downloading webmozart/assert (1.9.1)
  - Downloading phpdocumentor/reflection-common (1.0.1)
  - Downloading phpdocumentor/type-resolver (0.4.0)
  - Downloading phpdocumentor/reflection-docblock (3.3.2)
  - Downloading symfony/filesystem (v3.4.46)
  - Downloading psr/container (1.0.0)
  - Downloading symfony/dependency-injection (v3.4.46)
  - Downloading symfony/config (v3.4.46)
  - Downloading pdepend/pdepend (2.8.0)
  - Downloading psr/log (1.1.3)
  - Downloading composer/xdebug-handler (1.4.4)
  - Downloading phpmd/phpmd (2.9.1)
  - Downloading phpunit/php-token-stream (1.4.12)
  - Downloading symfony/yaml (v3.4.46)
  - Downloading sebastian/version (2.0.1)
  - Downloading sebastian/resource-operations (1.0.0)
  - Downloading sebastian/recursion-context (2.0.0)
  - Downloading sebastian/object-enumerator (2.0.1)
  - Downloading sebastian/global-state (1.1.1)
  - Downloading sebastian/exporter (2.0.0)
  - Downloading sebastian/environment (2.0.0)
  - Downloading sebastian/diff (1.4.3)
  - Downloading sebastian/comparator (1.2.4)
  - Downloading phpunit/php-text-template (1.2.1)
  - Downloading doctrine/instantiator (1.0.5)
  - Downloading phpunit/phpunit-mock-objects (3.4.4)
  - Downloading phpunit/php-timer (1.0.9)
  - Downloading phpunit/php-file-iterator (1.4.5)
  - Downloading sebastian/code-unit-reverse-lookup (1.0.1)
  - Downloading phpunit/php-code-coverage (4.0.8)
  - Downloading phpspec/prophecy (v1.10.3)
  - Downloading myclabs/deep-copy (1.7.0)
  - Downloading phpunit/phpunit (5.7.27)
  0/36 [>---------------------------]   0%
  2/36 [=>--------------------------]   5%
  3/36 [==>-------------------------]   8%
  4/36 [===>------------------------]  11%
  5/36 [===>------------------------]  13%
  6/36 [====>-----------------------]  16%
  7/36 [=====>----------------------]  19%
  8/36 [======>---------------------]  22%
  9/36 [=======>--------------------]  25%
 10/36 [=======>--------------------]  27%
 11/36 [========>-------------------]  30%
 12/36 [=========>------------------]  33%
 13/36 [==========>-----------------]  36%
 14/36 [==========>-----------------]  38%
 15/36 [===========>----------------]  41%
 17/36 [=============>--------------]  47%
 18/36 [==============>-------------]  50%
 19/36 [==============>-------------]  52%
 20/36 [===============>------------]  55%
 21/36 [================>-----------]  58%
 22/36 [=================>----------]  61%
 23/36 [=================>----------]  63%
 24/36 [==================>---------]  66%
 25/36 [===================>--------]  69%
 26/36 [====================>-------]  72%
 27/36 [=====================>------]  75%
 28/36 [=====================>------]  77%
 29/36 [======================>-----]  80%
 30/36 [=======================>----]  83%
 31/36 [========================>---]  86%
 32/36 [========================>---]  88%
 33/36 [=========================>--]  91%
 34/36 [==========================>-]  94%
 35/36 [===========================>]  97%
 36/36 [============================] 100%  - Installing squizlabs/php_codesniffer (3.5.8): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.0): Extracting archive
  - Installing symfony/polyfill-ctype (v1.19.0): Extracting archive
  - Installing webmozart/assert (1.9.1): Extracting archive
  - Installing phpdocumentor/reflection-common (1.0.1): Extracting archive
  - Installing phpdocumentor/type-resolver (0.4.0): Extracting archive
  - Installing phpdocumentor/reflection-docblock (3.3.2): Extracting archive
  - Installing symfony/filesystem (v3.4.46): Extracting archive
  - Installing psr/container (1.0.0): Extracting archive
  - Installing symfony/dependency-injection (v3.4.46): Extracting archive
  - Installing symfony/config (v3.4.46): Extracting archive
  - Installing pdepend/pdepend (2.8.0): Extracting archive
  - Installing psr/log (1.1.3): Extracting archive
  - Installing composer/xdebug-handler (1.4.4): Extracting archive
  - Installing phpmd/phpmd (2.9.1): Extracting archive
  - Installing phpunit/php-token-stream (1.4.12): Extracting archive
  - Installing symfony/yaml (v3.4.46): Extracting archive
  - Installing sebastian/version (2.0.1): Extracting archive
  - Installing sebastian/resource-operations (1.0.0): Extracting archive
  - Installing sebastian/recursion-context (2.0.0): Extracting archive
  - Installing sebastian/object-enumerator (2.0.1): Extracting archive
  - Installing sebastian/global-state (1.1.1): Extracting archive
  - Installing sebastian/exporter (2.0.0): Extracting archive
  - Installing sebastian/environment (2.0.0): Extracting archive
  - Installing sebastian/diff (1.4.3): Extracting archive
  - Installing sebastian/comparator (1.2.4): Extracting archive
  - Installing phpunit/php-text-template (1.2.1): Extracting archive
  - Installing doctrine/instantiator (1.0.5): Extracting archive
  - Installing phpunit/phpunit-mock-objects (3.4.4): Extracting archive
  - Installing phpunit/php-timer (1.0.9): Extracting archive
  - Installing phpunit/php-file-iterator (1.4.5): Extracting archive
  - Installing sebastian/code-unit-reverse-lookup (1.0.1): Extracting archive
  - Installing phpunit/php-code-coverage (4.0.8): Extracting archive
  - Installing phpspec/prophecy (v1.10.3): Extracting archive
  - Installing myclabs/deep-copy (1.7.0): Extracting archive
  - Installing phpunit/phpunit (5.7.27): Extracting archive
  0/24 [>---------------------------]   0%
 10/24 [===========>----------------]  41%
 20/24 [=======================>----]  83%
 21/24 [========================>---]  87%
 24/24 [============================] 100%Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
8 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/packages.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.0 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.9 for phpmd/phpmd
Using version ^5.7 for phpunit/phpunit
Using version ^3.5 for squizlabs/php_codesniffer
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd phpunit/phpunit squizlabs/php_codesniffer
Loading composer repositories with package information
Updating dependencies
Lock file operations: 36 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (1.4.5)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.0)
  - Locking doctrine/instantiator (1.0.5)
  - Locking myclabs/deep-copy (1.7.0)
  - Locking pdepend/pdepend (2.8.0)
  - Locking phpdocumentor/reflection-common (1.0.1)
  - Locking phpdocumentor/reflection-docblock (3.3.2)
  - Locking phpdocumentor/type-resolver (0.4.0)
  - Locking phpmd/phpmd (2.9.1)
  - Locking phpspec/prophecy (v1.10.3)
  - Locking phpunit/php-code-coverage (4.0.8)
  - Locking phpunit/php-file-iterator (1.4.5)
  - Locking phpunit/php-text-template (1.2.1)
  - Locking phpunit/php-timer (1.0.9)
  - Locking phpunit/php-token-stream (1.4.12)
  - Locking phpunit/phpunit (5.7.27)
  - Locking phpunit/phpunit-mock-objects (3.4.4)
  - Locking psr/container (1.0.0)
  - Locking psr/log (1.1.3)
  - Locking sebastian/code-unit-reverse-lookup (1.0.1)
  - Locking sebastian/comparator (1.2.4)
  - Locking sebastian/diff (1.4.3)
  - Locking sebastian/environment (2.0.0)
  - Locking sebastian/exporter (2.0.0)
  - Locking sebastian/global-state (1.1.1)
  - Locking sebastian/object-enumerator (2.0.1)
  - Locking sebastian/recursion-context (2.0.0)
  - Locking sebastian/resource-operations (1.0.0)
  - Locking sebastian/version (2.0.1)
  - Locking squizlabs/php_codesniffer (3.5.8)
  - Locking symfony/config (v3.4.46)
  - Locking symfony/dependency-injection (v3.4.46)
  - Locking symfony/filesystem (v3.4.46)
  - Locking symfony/polyfill-ctype (v1.19.0)
  - Locking symfony/yaml (v3.4.46)
  - Locking webmozart/assert (1.9.1)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 36 installs, 0 updates, 0 removals
  - Downloading composer/xdebug-handler (1.4.5)
 0/1 [>---------------------------]   0%
 1/1 [============================] 100%  - Installing squizlabs/php_codesniffer (3.5.8): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.0): Extracting archive
  - Installing symfony/polyfill-ctype (v1.19.0): Extracting archive
  - Installing webmozart/assert (1.9.1): Extracting archive
  - Installing phpdocumentor/reflection-common (1.0.1): Extracting archive
  - Installing phpdocumentor/type-resolver (0.4.0): Extracting archive
  - Installing phpdocumentor/reflection-docblock (3.3.2): Extracting archive
  - Installing symfony/filesystem (v3.4.46): Extracting archive
  - Installing psr/container (1.0.0): Extracting archive
  - Installing symfony/dependency-injection (v3.4.46): Extracting archive
  - Installing symfony/config (v3.4.46): Extracting archive
  - Installing pdepend/pdepend (2.8.0): Extracting archive
  - Installing psr/log (1.1.3): Extracting archive
  - Installing composer/xdebug-handler (1.4.5): Extracting archive
  - Installing phpmd/phpmd (2.9.1): Extracting archive
  - Installing phpunit/php-token-stream (1.4.12): Extracting archive
  - Installing symfony/yaml (v3.4.46): Extracting archive
  - Installing sebastian/version (2.0.1): Extracting archive
  - Installing sebastian/resource-operations (1.0.0): Extracting archive
  - Installing sebastian/recursion-context (2.0.0): Extracting archive
  - Installing sebastian/object-enumerator (2.0.1): Extracting archive
  - Installing sebastian/global-state (1.1.1): Extracting archive
  - Installing sebastian/exporter (2.0.0): Extracting archive
  - Installing sebastian/environment (2.0.0): Extracting archive
  - Installing sebastian/diff (1.4.3): Extracting archive
  - Installing sebastian/comparator (1.2.4): Extracting archive
  - Installing phpunit/php-text-template (1.2.1): Extracting archive
  - Installing doctrine/instantiator (1.0.5): Extracting archive
  - Installing phpunit/phpunit-mock-objects (3.4.4): Extracting archive
  - Installing phpunit/php-timer (1.0.9): Extracting archive
  - Installing phpunit/php-file-iterator (1.4.5): Extracting archive
  - Installing sebastian/code-unit-reverse-lookup (1.0.1): Extracting archive
  - Installing phpunit/php-code-coverage (4.0.8): Extracting archive
  - Installing phpspec/prophecy (v1.10.3): Extracting archive
  - Installing myclabs/deep-copy (1.7.0): Extracting archive
  - Installing phpunit/phpunit (5.7.27): Extracting archive
  0/24 [>---------------------------]   0%
 10/24 [===========>----------------]  41%
 20/24 [=======================>----]  83%
 21/24 [========================>---]  87%
 24/24 [============================] 100%6 package suggestions were added by new dependencies, use `composer suggest` to see details.
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
8 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- composer.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)